### PR TITLE
Command fail to execute on mainnet build - Closes #8

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -40,13 +40,14 @@ export const getConfig = async (corePath: string, customConfigPath?: string): Pr
 	const fullCommand = command.join(' ');
 	const compiledConfigPath = join(corePath, compiledConfig);
 
-	console.info('Execurting command to fetch the configuration');
+	console.info('Executing command to fetch the configuration');
 	console.info(fullCommand);
 
-	// Excuting command to compile the configuration
-	execSync(fullCommand);
+	// Executing command to compile the configuration
+	// 	to use the "source" command on Linux we have to explicity set shell to bash
+	execSync(fullCommand, { shell: '/bin/bash' });
 
-	// Loading compiled configuraiton file
+	// Loading compiled configuration file
 	const config = await import(compiledConfigPath);
 
 	// Deleting compiled configuration file

--- a/src/utils/genesis_block.ts
+++ b/src/utils/genesis_block.ts
@@ -395,6 +395,11 @@ export const createGenesisBlockFromStorage = async ({
 			new MerkleTree(blocksBatch.map(block => hash(getBlockBytes(block)))).root,
 		);
 		lastBlock = blocksBatch[blocksBatch.length - 1];
+		debug(
+			`Processed block till height: ${lastBlock.height}, Remaining: ${
+				snapshotHeight - lastBlock.height
+			}`,
+		);
 	};
 	await db.stream(
 		new QueryStream(


### PR DESCRIPTION
### What was the problem?

This PR resolves #8

### How was it solved?

Explicitly set shell to `/bin/bash` to use `source` command. 

### How was it tested?

Tested the changes on a mainnet node. 
