### PR TITLE
Migrated non-delegate account should have default lastForgedHeight - Closes #15

### DIFF
--- a/src/utils/genesis_block.ts
+++ b/src/utils/genesis_block.ts
@@ -329,14 +329,17 @@ export const migrateLegacyAccount = async ({
 		};
 	}
 
-	const account = objects.mergeDeep(
+	let account = objects.mergeDeep(
 		{},
 		accountDefaultProps,
 		basicProps,
 		tokenProps,
-		dposProps,
 		keysProps,
 	) as Account;
+
+	if (legacyAccount.username !== '') {
+		account = objects.mergeDeep({}, account, dposProps) as Account;
+	}
 
 	debug('New account:', account);
 

--- a/test/unit/utils/genesis_block.spec.ts
+++ b/test/unit/utils/genesis_block.spec.ts
@@ -66,7 +66,7 @@ const expectAccountMigration = (
 			delegate: {
 				consecutiveMissedBlocks: 0,
 				isBanned: false,
-				lastForgedHeight: snapshotHeight + 1,
+				lastForgedHeight: legacyAccount.username === '' ? 0 : snapshotHeight + 1,
 				pomHeights: [],
 				totalVotesReceived: BigInt(0),
 				username: legacyAccount.username,


### PR DESCRIPTION
### What was the problem?

This PR resolves #15

### How was it solved?

- Added condition to override delegate related properties only for accounts which were delegate perviously  

### How was it tested?

- Run unit tests 
