### PR TITLE
Lisk Migrator is not compatible with Lisk Core v2.1.7 - Closes #27

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { observeChainHeight } from './utils/chain';
 import { createDb, verifyConnection, createSnapshot } from './utils/storage';
 import { createGenesisBlockFromStorage, writeGenesisBlock } from './utils/genesis_block';
 
-const compatibleVersions = '>=2.1.4 <=2.1.6';
+const compatibleVersions = '>=2.1.4 <=2.1';
 
 class LiskMigrator extends Command {
 	public static description = 'Migrate Lisk Core to latest version';

--- a/test/unit/lisk_migrator.spec.ts
+++ b/test/unit/lisk_migrator.spec.ts
@@ -195,7 +195,7 @@ describe('LiskMigrator', () => {
 				.mockResolvedValue({ ...appConfig, app: { ...appConfig.app, version } });
 
 			await expect(LiskMigrator.run(requiredFlags)).rejects.toThrow(
-				`Lisk-Migrator utility is not compatible for lisk-core version ${version}. Compatible versions range is: >=2.1.4 <=2.1.6`,
+				`Lisk-Migrator utility is not compatible for lisk-core version ${version}. Compatible versions range is: >=2.1.4 <=2.1`,
 			);
 		},
 	);

--- a/test/unit/lisk_migrator.spec.ts
+++ b/test/unit/lisk_migrator.spec.ts
@@ -187,7 +187,7 @@ describe('LiskMigrator', () => {
 		);
 	});
 
-	it.each(['2.1.3', '2.1.7'])(
+	it.each(['2.1.3', '2.1.0', '2.0.0', '2.2.0'])(
 		'should fail if lisk-core version "$1" does not satisfy',
 		async (version: string) => {
 			jest
@@ -197,6 +197,17 @@ describe('LiskMigrator', () => {
 			await expect(LiskMigrator.run(requiredFlags)).rejects.toThrow(
 				`Lisk-Migrator utility is not compatible for lisk-core version ${version}. Compatible versions range is: >=2.1.4 <=2.1`,
 			);
+		},
+	);
+
+	it.each(['2.1.4', '2.1.7', '2.1.8'])(
+		'should pass if lisk-core version "$1" satisfy',
+		async (version: string) => {
+			jest
+				.spyOn(utils, 'getConfig')
+				.mockResolvedValue({ ...appConfig, app: { ...appConfig.app, version } });
+
+			await expect(LiskMigrator.run(requiredFlags)).toResolve();
 		},
 	);
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #27 

### How was it solved?

- Extended Lisk Core version check

### How was it tested?

- Updated unit tests