### PR TITLE
Migrator could not read the custom configuration file - Closes #31

### DIFF
--- a/test/unit/lisk_migrator.spec.ts
+++ b/test/unit/lisk_migrator.spec.ts
@@ -72,6 +72,32 @@ describe('LiskMigrator', () => {
 			});
 		});
 
+		describe('custom config file', () => {
+			it('should use the custom config file if provided', async () => {
+				await LiskMigrator.run(
+					requiredFlags.concat(['-p', '/my/directory', '-c', 'my-custom-config.json']),
+				);
+
+				expect(utils.getConfig).toHaveBeenCalledWith('/my/directory', 'my-custom-config.json');
+			});
+
+			it('should use the default custom config path if not provided and its a binary build', async () => {
+				jest.spyOn(utils, 'isBinaryBuild').mockReturnValue(true);
+
+				await LiskMigrator.run(requiredFlags.concat(['-p', '/my/directory']));
+
+				expect(utils.getConfig).toHaveBeenCalledWith('/my/directory', '/my/directory/config.json');
+			});
+
+			it('should not use custom config path if not provided and its not a binary build', async () => {
+				jest.spyOn(utils, 'isBinaryBuild').mockReturnValue(false);
+
+				await LiskMigrator.run(requiredFlags.concat(['-p', '/my/directory']));
+
+				expect(utils.getConfig).toHaveBeenCalledWith('/my/directory');
+			});
+		});
+
 		describe('output', () => {
 			it('should use the output path if provided', async () => {
 				await LiskMigrator.run(requiredFlags.concat(['-o', '/my/directory/my_block.json']));


### PR DESCRIPTION
### What was the problem?

This PR resolves #31

### How was it solved?

- Added a new flag to read custom configuration file 

### How was it tested?

- Added unit tests 
