### PR TITLE
Remove usage section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,9 @@ Lisk Migrator is a command line tool to migrate the blockchain data to the lates
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
-## Usage
+## Setup
 
-<!-- usage -->
-
-```sh-session
-$ npm install -g lisk-migrator
-$ lisk-migrator COMMAND
-running command...
-$ lisk-migrator (-v|--version|version)
-lisk-migrator/1.0.0 darwin-x64 node-v12.22.1
-$ lisk-migrator --help [COMMAND]
-USAGE
-  $ lisk-migrator COMMAND
-...
-```
-
-<!-- usagestop -->
-
+Follow our Lisk Documentation guide for [setting up the Lisk migrator](https://lisk.com/documentation/lisk-core/management/migration.html#setting-up-the-lisk-migrator)
 ## Build Distributions (Linux, Darwin)
 
 <!-- build -->


### PR DESCRIPTION

### What was the problem?

This PR resolves #74

### How was it solved?

:recycle: Update README
Remove usage section since we are not publishing lisk-migrator to npm We can add it back if we decide to publish them during 2.0 release

### How was it tested?

NA