### PR TITLE
Optimize migrator implementation #2

### DIFF
--- a/src/assets/auth.ts
+++ b/src/assets/auth.ts
@@ -11,12 +11,21 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { Account, AuthAccountEntry, AuthStoreEntryBuffer } from '../types';
+import { getLisk32AddressFromAddress } from '@liskhq/lisk-cryptography';
+import {
+	Account,
+	AuthAccountEntry,
+	AuthStoreEntry,
+	AuthStoreEntryBuffer,
+	GenesisAssetEntry,
+} from '../types';
+import { MODULE_NAME_AUTH } from '../constants';
+import { genesisAuthStoreSchema } from '../schemas';
 
 const keyMapper = (key: Buffer) => key.toString('hex');
 const keyComparator = (a: Buffer, b: Buffer) => a.compare(b);
 
-export const addAuthModuleEntry = async (account: Account): Promise<AuthStoreEntryBuffer> => {
+export const getAuthModuleEntry = async (account: Account): Promise<AuthStoreEntryBuffer> => {
 	const authObj: AuthAccountEntry = {
 		numberOfSignatures: account.keys.numberOfSignatures,
 		mandatoryKeys: account.keys.mandatoryKeys.sort(keyComparator).map(keyMapper),
@@ -27,5 +36,22 @@ export const addAuthModuleEntry = async (account: Account): Promise<AuthStoreEnt
 	return {
 		storeKey: account.address,
 		storeValue: authObj,
+	};
+};
+
+export const addAuthModuleEntry = async (
+	authStoreEntriesBuffer: AuthStoreEntryBuffer[],
+): Promise<GenesisAssetEntry> => {
+	const sortedAuthSubstoreEntries: AuthStoreEntry[] = authStoreEntriesBuffer
+		.sort((a, b) => a.storeKey.compare(b.storeKey))
+		.map(entry => ({
+			...entry,
+			storeKey: getLisk32AddressFromAddress(entry.storeKey),
+		}));
+
+	return {
+		module: MODULE_NAME_AUTH,
+		data: ({ authDataSubstore: sortedAuthSubstoreEntries } as unknown) as Record<string, unknown>,
+		schema: genesisAuthStoreSchema,
 	};
 };

--- a/src/assets/auth.ts
+++ b/src/assets/auth.ts
@@ -11,7 +11,6 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { getLisk32AddressFromAddress } from '@liskhq/lisk-cryptography';
 import {
 	Account,
 	AuthAccountEntry,
@@ -25,7 +24,7 @@ import { genesisAuthStoreSchema } from '../schemas';
 const keyMapper = (key: Buffer) => key.toString('hex');
 const keyComparator = (a: Buffer, b: Buffer) => a.compare(b);
 
-export const getAuthModuleEntry = async (account: Account): Promise<AuthStoreEntryBuffer> => {
+export const getAuthModuleEntryBuffer = async (account: Account): Promise<AuthStoreEntryBuffer> => {
 	const authObj: AuthAccountEntry = {
 		numberOfSignatures: account.keys.numberOfSignatures,
 		mandatoryKeys: account.keys.mandatoryKeys.sort(keyComparator).map(keyMapper),
@@ -39,19 +38,10 @@ export const getAuthModuleEntry = async (account: Account): Promise<AuthStoreEnt
 	};
 };
 
-export const addAuthModuleEntry = async (
-	authStoreEntriesBuffer: AuthStoreEntryBuffer[],
-): Promise<GenesisAssetEntry> => {
-	const sortedAuthSubstoreEntries: AuthStoreEntry[] = authStoreEntriesBuffer
-		.sort((a, b) => a.storeKey.compare(b.storeKey))
-		.map(entry => ({
-			...entry,
-			storeKey: getLisk32AddressFromAddress(entry.storeKey),
-		}));
-
-	return {
-		module: MODULE_NAME_AUTH,
-		data: ({ authDataSubstore: sortedAuthSubstoreEntries } as unknown) as Record<string, unknown>,
-		schema: genesisAuthStoreSchema,
-	};
-};
+export const getAuthModuleEntry = async (
+	authStoreEntries: AuthStoreEntry[],
+): Promise<GenesisAssetEntry> => ({
+	module: MODULE_NAME_AUTH,
+	data: ({ authDataSubstore: authStoreEntries } as unknown) as Record<string, unknown>,
+	schema: genesisAuthStoreSchema,
+});

--- a/src/assets/auth.ts
+++ b/src/assets/auth.ts
@@ -11,48 +11,21 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { getLisk32AddressFromAddress } from '@liskhq/lisk-cryptography';
-
-import { MODULE_NAME_AUTH } from '../constants';
-import { genesisAuthStoreSchema } from '../schemas';
-import {
-	Account,
-	AuthAccountEntry,
-	AuthStoreEntry,
-	AuthStoreEntryBuffer,
-	GenesisAssetEntry,
-} from '../types';
+import { Account, AuthAccountEntry, AuthStoreEntryBuffer } from '../types';
 
 const keyMapper = (key: Buffer) => key.toString('hex');
 const keyComparator = (a: Buffer, b: Buffer) => a.compare(b);
 
-export const addAuthModuleEntry = async (accounts: Account[]): Promise<GenesisAssetEntry> => {
-	const authSubstoreEntries: AuthStoreEntryBuffer[] = await Promise.all(
-		accounts.map(async (account: Account) => {
-			const authObj: AuthAccountEntry = {
-				numberOfSignatures: account.keys.numberOfSignatures,
-				mandatoryKeys: account.keys.mandatoryKeys.sort(keyComparator).map(keyMapper),
-				optionalKeys: account.keys.optionalKeys.sort(keyComparator).map(keyMapper),
-				nonce: String(account.sequence.nonce),
-			};
-
-			return {
-				storeKey: account.address,
-				storeValue: authObj,
-			};
-		}),
-	);
-
-	const sortedAuthSubstoreEntries: AuthStoreEntry[] = authSubstoreEntries
-		.sort((a, b) => a.storeKey.compare(b.storeKey))
-		.map(entry => ({
-			...entry,
-			storeKey: getLisk32AddressFromAddress(entry.storeKey),
-		}));
+export const addAuthModuleEntry = async (account: Account): Promise<AuthStoreEntryBuffer> => {
+	const authObj: AuthAccountEntry = {
+		numberOfSignatures: account.keys.numberOfSignatures,
+		mandatoryKeys: account.keys.mandatoryKeys.sort(keyComparator).map(keyMapper),
+		optionalKeys: account.keys.optionalKeys.sort(keyComparator).map(keyMapper),
+		nonce: String(account.sequence.nonce),
+	};
 
 	return {
-		module: MODULE_NAME_AUTH,
-		data: ({ authDataSubstore: sortedAuthSubstoreEntries } as unknown) as Record<string, unknown>,
-		schema: genesisAuthStoreSchema,
+		storeKey: account.address,
+		storeValue: authObj,
 	};
 };

--- a/src/assets/interoperability.ts
+++ b/src/assets/interoperability.ts
@@ -15,7 +15,7 @@ import { genesisInteroperabilitySchema } from 'lisk-framework';
 import { MODULE_NAME_INTEROPERABILITY, CHAIN_NAME_MAINCHAIN } from '../constants';
 import { GenesisAssetEntry, GenesisInteroperability } from '../types';
 
-export const addInteropModuleEntry = async (): Promise<GenesisAssetEntry> => {
+export const getInteropModuleEntry = async (): Promise<GenesisAssetEntry> => {
 	const interopObj = ({
 		ownChainName: CHAIN_NAME_MAINCHAIN,
 		ownChainNonce: BigInt('0'),

--- a/src/assets/legacy.ts
+++ b/src/assets/legacy.ts
@@ -26,7 +26,7 @@ import {
 const AMOUNT_ZERO = BigInt('0');
 let legacyReserveAmount: bigint = AMOUNT_ZERO;
 
-export const addLegacyModuleEntry = async (
+export const getLegacyModuleEntry = async (
 	encodedUnregisteredAddresses: Buffer,
 	legacyReserveAccount: Account | undefined,
 ): Promise<GenesisAssetEntry> => {
@@ -37,16 +37,14 @@ export const addLegacyModuleEntry = async (
 		encodedUnregisteredAddresses,
 	);
 
-	const legacyAccounts: LegacyStoreEntryBuffer[] = await Promise.all(
-		unregisteredAddresses.map(async account => {
-			legacyReserveAmount += BigInt(account.balance);
+	const legacyAccounts: LegacyStoreEntryBuffer[] = unregisteredAddresses.map(account => {
+		legacyReserveAmount += BigInt(account.balance);
 
-			return {
-				address: account.address,
-				balance: String(account.balance),
-			};
-		}),
-	);
+		return {
+			address: account.address,
+			balance: String(account.balance),
+		};
+	});
 
 	const sortedLegacyAccounts: LegacyStoreEntry[] = legacyAccounts
 		.sort((a, b) => a.address.compare(b.address))

--- a/src/assets/pos.ts
+++ b/src/assets/pos.ts
@@ -28,6 +28,7 @@ import {
 	DB_KEY_BLOCKS_HEIGHT,
 	DB_KEY_BLOCKS_ID,
 	MODULE_NAME_POS,
+	EMPTY_STRING,
 } from '../constants';
 
 import {
@@ -98,7 +99,7 @@ export const createValidatorsArrayEntry = async (
 	snapshotHeight: number,
 	tokenID: string,
 ): Promise<ValidatorEntryBuffer | null> => {
-	if (account.dpos.delegate.username !== '') {
+	if (account.dpos.delegate.username !== EMPTY_STRING) {
 		const validatorAddress = account.address.toString('hex');
 
 		const validator: ValidatorEntryBuffer = Object.freeze({
@@ -207,7 +208,7 @@ export const createGenesisDataObj = async (
 	return genesisDataObj;
 };
 
-export const addPoSModuleEntry = async (
+export const getPoSModuleEntry = async (
 	validators: ValidatorEntry[],
 	stakers: Staker[],
 	genesisData: GenesisDataEntry,

--- a/src/assets/pos.ts
+++ b/src/assets/pos.ts
@@ -11,6 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+import { posGenesisStoreSchema } from 'lisk-framework';
 import { KVStore, formatInt } from '@liskhq/lisk-db';
 import { codec } from '@liskhq/lisk-codec';
 import { BlockHeader, Transaction } from '@liskhq/lisk-chain';
@@ -26,6 +27,7 @@ import {
 	MAX_COMMISSION,
 	DB_KEY_BLOCKS_HEIGHT,
 	DB_KEY_BLOCKS_ID,
+	MODULE_NAME_POS,
 } from '../constants';
 
 import {
@@ -37,6 +39,10 @@ import {
 	ValidatorEntryBuffer,
 	Stake,
 	StakerBuffer,
+	ValidatorEntry,
+	Staker,
+	GenesisAssetEntry,
+	PoSStoreEntry,
 } from '../types';
 
 import { blockHeaderSchema } from '../schemas';
@@ -86,7 +92,7 @@ export const getValidatorKeys = async (
 	return keys;
 };
 
-export const createValidatorsArray = async (
+export const createValidatorsArrayEntry = async (
 	account: Account,
 	validatorKeys: Record<string, string>,
 	snapshotHeight: number,
@@ -141,7 +147,7 @@ export const getStakes = async (account: Account, tokenID: string): Promise<Stak
 	return sortedStakes;
 };
 
-export const createStakersArray = async (
+export const createStakersArrayEntry = async (
 	account: Account,
 	tokenID: string,
 ): Promise<StakerBuffer | null> => {
@@ -199,4 +205,22 @@ export const createGenesisDataObj = async (
 	};
 
 	return genesisDataObj;
+};
+
+export const addPoSModuleEntry = async (
+	validators: ValidatorEntry[],
+	stakers: Staker[],
+	genesisData: GenesisDataEntry,
+): Promise<GenesisAssetEntry> => {
+	const posObj: PoSStoreEntry = {
+		validators,
+		stakers,
+		genesisData,
+	};
+
+	return {
+		module: MODULE_NAME_POS,
+		data: (posObj as unknown) as Record<string, unknown>,
+		schema: posGenesisStoreSchema,
+	};
 };

--- a/src/assets/token.ts
+++ b/src/assets/token.ts
@@ -11,9 +11,24 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { MODULE_NAME_POS, MODULE_NAME_LEGACY, ADDRESS_LEGACY_RESERVE } from '../constants';
+import { tokenGenesisStoreSchema } from 'lisk-framework';
 
-import { Account, LockedBalance, UserSubstoreEntryBuffer } from '../types';
+import {
+	MODULE_NAME_POS,
+	MODULE_NAME_LEGACY,
+	ADDRESS_LEGACY_RESERVE,
+	MODULE_NAME_TOKEN,
+} from '../constants';
+
+import {
+	Account,
+	GenesisAssetEntry,
+	LockedBalance,
+	SupplySubstoreEntry,
+	TokenStoreEntry,
+	UserSubstoreEntry,
+	UserSubstoreEntryBuffer,
+} from '../types';
 
 const AMOUNT_ZERO = BigInt('0');
 
@@ -61,7 +76,7 @@ export const createLegacyReserveAccount = async (
 	return legacyReserve;
 };
 
-export const createUserSubstoreArray = async (
+export const createUserSubstoreArrayEntry = async (
 	account: Account,
 	tokenID: string,
 ): Promise<UserSubstoreEntryBuffer | null> => {
@@ -79,4 +94,23 @@ export const createUserSubstoreArray = async (
 		}
 	}
 	return null;
+};
+
+export const addTokenModuleEntry = async (
+	userSubstore: UserSubstoreEntry[],
+	supplySubstore: SupplySubstoreEntry[],
+	escrowSubstore: never[],
+	supportedTokensSubstore: never[],
+): Promise<GenesisAssetEntry> => {
+	const tokenObj: TokenStoreEntry = {
+		userSubstore,
+		supplySubstore,
+		escrowSubstore,
+		supportedTokensSubstore,
+	};
+	return {
+		module: MODULE_NAME_TOKEN,
+		data: (tokenObj as unknown) as Record<string, unknown>,
+		schema: tokenGenesisStoreSchema,
+	};
 };

--- a/src/assets/token.ts
+++ b/src/assets/token.ts
@@ -22,9 +22,11 @@ import {
 
 import {
 	Account,
+	EscrowSubstoreEntry,
 	GenesisAssetEntry,
 	LockedBalance,
 	SupplySubstoreEntry,
+	SupportedTokensSubstoreEntry,
 	TokenStoreEntry,
 	UserSubstoreEntry,
 	UserSubstoreEntryBuffer,
@@ -96,11 +98,11 @@ export const createUserSubstoreArrayEntry = async (
 	return null;
 };
 
-export const addTokenModuleEntry = async (
+export const getTokenModuleEntry = async (
 	userSubstore: UserSubstoreEntry[],
 	supplySubstore: SupplySubstoreEntry[],
-	escrowSubstore: never[],
-	supportedTokensSubstore: never[],
+	escrowSubstore: EscrowSubstoreEntry[],
+	supportedTokensSubstore: SupportedTokensSubstoreEntry[],
 ): Promise<GenesisAssetEntry> => {
 	const tokenObj: TokenStoreEntry = {
 		userSubstore,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,6 +74,7 @@ export const DEFAULT_HOST = '127.0.0.1';
 export const DEFAULT_PORT_P2P = 7667;
 export const DEFAULT_PORT_RPC = 7887;
 
+export const EMPTY_STRING = '';
 export const EMPTY_BYTES = Buffer.alloc(0);
 export const SHA_256_HASH_LENGTH = 32;
 export const BINARY_ADDRESS_LENGTH = 20;

--- a/src/createAsset.ts
+++ b/src/createAsset.ts
@@ -11,8 +11,10 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+import { posGenesisStoreSchema, tokenGenesisStoreSchema } from 'lisk-framework';
 import { codec } from '@liskhq/lisk-codec';
 import { KVStore } from '@liskhq/lisk-db';
+import { getLisk32AddressFromAddress } from '@liskhq/lisk-cryptography';
 
 import {
 	CHAIN_STATE_UNREGISTERED_ADDRESSES,
@@ -20,18 +22,46 @@ import {
 	DB_KEY_CHAIN_STATE,
 	DB_KEY_ACCOUNTS_ADDRESS,
 	BINARY_ADDRESS_LENGTH,
+	MODULE_NAME_AUTH,
+	MODULE_NAME_TOKEN,
+	ADDRESS_LEGACY_RESERVE,
+	MODULE_NAME_POS,
 } from './constants';
-import { accountSchema, voteWeightsSchema } from './schemas';
-import { Account, LegacyStoreEntry, VoteWeightsWrapper, GenesisAssetEntry } from './types';
+import { accountSchema, genesisAuthStoreSchema, voteWeightsSchema } from './schemas';
+import {
+	Account,
+	VoteWeightsWrapper,
+	GenesisAssetEntry,
+	AuthStoreEntry,
+	UserSubstoreEntry,
+	UserSubstoreEntryBuffer,
+	SupplySubstoreEntry,
+	AuthStoreEntryBuffer,
+	TokenStoreEntry,
+	ValidatorEntryBuffer,
+	PoSStoreEntry,
+	StakerBuffer,
+} from './types';
 
 import { addInteropModuleEntry } from './assets/interoperability';
-import { addLegacyModuleEntry } from './assets/legacy';
 import { addAuthModuleEntry } from './assets/auth';
-import { addTokenModuleEntry } from './assets/token';
-import { addPoSModuleEntry } from './assets/pos';
+import {
+	createLegacyReserveAccount,
+	createUserSubstoreArray,
+	getLockedBalances,
+} from './assets/token';
+import {
+	createGenesisDataObj,
+	createStakersArray,
+	createValidatorsArray,
+	getValidatorKeys,
+} from './assets/pos';
+import { addLegacyModuleEntry, getLegacyReserveAmount } from './assets/legacy';
 
 import { getDataFromDBStream } from './utils/block';
 
+const AMOUNT_ZERO = BigInt('0');
+let totalLSKSupply = AMOUNT_ZERO;
 export class CreateAsset {
 	private readonly _db: KVStore;
 
@@ -44,11 +74,15 @@ export class CreateAsset {
 		snapshotHeightPrevious: number,
 		tokenID: string,
 	): Promise<GenesisAssetEntry[]> => {
+		const authSubstoreEntries: AuthStoreEntryBuffer[] = [];
+		const userSubstore: UserSubstoreEntryBuffer[] = [];
+		const supplySubstore: SupplySubstoreEntry[] = [];
+		const validators: ValidatorEntryBuffer[] = [];
+		const stakers: StakerBuffer[] = [];
+
 		const encodedUnregisteredAddresses = await this._db.get(
 			`${DB_KEY_CHAIN_STATE}:${CHAIN_STATE_UNREGISTERED_ADDRESSES}`,
 		);
-
-		const legacyModuleAssets = await addLegacyModuleEntry(encodedUnregisteredAddresses);
 
 		const accountStream = await this._db.createReadStream({
 			gte: `${DB_KEY_ACCOUNTS_ADDRESS}:${Buffer.alloc(20, 0).toString('binary')}`,
@@ -64,27 +98,154 @@ export class CreateAsset {
 			(acc: Account) => acc.address.length === BINARY_ADDRESS_LENGTH,
 		);
 
-		const authModuleAssets = await addAuthModuleEntry(accounts);
+		// Filter legacy account from the accounts
+		const legacyReserveAccount: Account | undefined = accounts.find(account =>
+			ADDRESS_LEGACY_RESERVE.equals(account.address),
+		);
 
-		const legacyAccounts: LegacyStoreEntry[] = legacyModuleAssets.data
-			.accounts as LegacyStoreEntry[];
-		const tokenModuleAssets = await addTokenModuleEntry(accounts, legacyAccounts, tokenID);
+		// Create legacy module assets
+		const legacyModuleAssets = await addLegacyModuleEntry(
+			encodedUnregisteredAddresses,
+			legacyReserveAccount,
+		);
+
+		// Get legacy reserve amount from cache
+		const legacyReserveAmount = getLegacyReserveAmount();
+
+		// Create legacy reserve for token module user substore
+		const legacyReserve = await createLegacyReserveAccount(
+			legacyReserveAccount,
+			legacyReserveAmount,
+			tokenID,
+		);
+
+		// Get all validator keys for PoS module
+		const validatorKeys = await getValidatorKeys(
+			accounts,
+			snapshotHeight,
+			snapshotHeightPrevious,
+			this._db,
+		);
+
+		for (const account of accounts) {
+			// genesis asset for auth module
+			const authModuleAsset = await addAuthModuleEntry(account);
+			authSubstoreEntries.push(authModuleAsset);
+
+			// genesis asset for token module
+			// Create user subtore entry
+			const userSubstoreEntry = await createUserSubstoreArray(account, tokenID);
+			if (userSubstoreEntry) userSubstore.push(userSubstoreEntry);
+
+			// Create total lisk supply for supply subtore
+			totalLSKSupply += BigInt(account.token.balance);
+			const lockedBalances = await getLockedBalances(account);
+			totalLSKSupply = lockedBalances.reduce(
+				(accumulator, lockedBalance) => accumulator + BigInt(lockedBalance.amount),
+				totalLSKSupply,
+			);
+
+			// genesis asset for PoS module
+			// Create validator entry
+			const validator = await createValidatorsArray(
+				account,
+				validatorKeys,
+				snapshotHeight,
+				tokenID,
+			);
+			if (validator) validators.push(validator);
+
+			// Create staker entry
+			const staker = await createStakersArray(account, tokenID);
+			if (staker) stakers.push(staker);
+		}
+
+		// Sort auth store entries in lexicographical order
+		const sortedAuthSubstoreEntries: AuthStoreEntry[] = authSubstoreEntries
+			.sort((a, b) => a.storeKey.compare(b.storeKey))
+			.map(entry => ({
+				...entry,
+				storeKey: getLisk32AddressFromAddress(entry.storeKey),
+			}));
+
+		const authModuleAssets = {
+			module: MODULE_NAME_AUTH,
+			data: ({ authDataSubstore: sortedAuthSubstoreEntries } as unknown) as Record<string, unknown>,
+			schema: genesisAuthStoreSchema,
+		};
+
+		// Add legacy reserve to user substore array
+		userSubstore.push(legacyReserve);
+		// Sort user substore entries in lexicographical order
+		const sortedUserSubstore: UserSubstoreEntry[] = userSubstore
+			.sort((a: UserSubstoreEntryBuffer, b: UserSubstoreEntryBuffer) =>
+				a.address.equals(b.address) ? a.tokenID.compare(b.tokenID) : a.address.compare(b.address),
+			)
+			.map(entry => ({
+				...entry,
+				address: getLisk32AddressFromAddress(entry.address),
+				tokenID: entry.tokenID.toString('hex'),
+			}));
+
+		// Add legacy reserve amount to total lisk supply
+		supplySubstore.push({
+			tokenID,
+			totalSupply: String(totalLSKSupply + legacyReserveAmount),
+		});
+
+		const tokenObj: TokenStoreEntry = {
+			userSubstore: sortedUserSubstore,
+			supplySubstore,
+			escrowSubstore: [],
+			supportedTokensSubstore: [],
+		};
+
+		const tokenModuleAssets = {
+			module: MODULE_NAME_TOKEN,
+			data: (tokenObj as unknown) as Record<string, unknown>,
+			schema: tokenGenesisStoreSchema,
+		};
+
+		// Sort validators substore entries in lexicographical order
+		const sortedValidators = validators
+			.sort((a, b) => a.address.compare(b.address))
+			.map(entry => ({
+				...entry,
+				address: getLisk32AddressFromAddress(entry.address),
+			}));
+
+		// Sort stakers substore entries in lexicographical order
+		const sortedStakers = stakers
+			.sort((a, b) => a.address.compare(b.address))
+			.map(({ address, ...entry }) => ({
+				...entry,
+				address: getLisk32AddressFromAddress(address),
+			}));
 
 		const encodedDelegatesVoteWeights = await this._db.get(
 			`${DB_KEY_CHAIN_STATE}:${CHAIN_STATE_DELEGATE_VOTE_WEIGHTS}`,
 		);
+
 		const decodedDelegatesVoteWeights: VoteWeightsWrapper = await codec.decode(
 			voteWeightsSchema,
 			encodedDelegatesVoteWeights,
 		);
-		const posModuleAssets = await addPoSModuleEntry(
-			accounts,
-			decodedDelegatesVoteWeights,
-			snapshotHeight,
-			snapshotHeightPrevious,
-			tokenID,
-			this._db,
-		);
+
+		const posObj: PoSStoreEntry = {
+			validators: sortedValidators,
+			stakers: sortedStakers,
+			genesisData: await createGenesisDataObj(
+				accounts,
+				decodedDelegatesVoteWeights,
+				snapshotHeight,
+			),
+		};
+
+		const posModuleAssets = {
+			module: MODULE_NAME_POS,
+			data: (posObj as unknown) as Record<string, unknown>,
+			schema: posGenesisStoreSchema,
+		};
 
 		const interoperabilityModuleAssets = await addInteropModuleEntry();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,8 +178,8 @@ export interface SupplySubstoreEntry {
 export interface TokenStoreEntry {
 	userSubstore: UserSubstoreEntry[];
 	supplySubstore: SupplySubstoreEntry[];
-	escrowSubstore: [];
-	supportedTokensSubstore: [];
+	escrowSubstore: never[];
+	supportedTokensSubstore: never[];
 }
 
 export interface SharingCoefficient {

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,11 +175,22 @@ export interface SupplySubstoreEntry {
 	totalSupply: string;
 }
 
+export interface EscrowSubstoreEntry {
+	escrowChainID: Buffer;
+	tokenID: Buffer;
+	amount: bigint;
+}
+
+export interface SupportedTokensSubstoreEntry {
+	chainID: Buffer;
+	supportedTokenIDs: Buffer[];
+}
+
 export interface TokenStoreEntry {
 	userSubstore: UserSubstoreEntry[];
 	supplySubstore: SupplySubstoreEntry[];
-	escrowSubstore: never[];
-	supportedTokensSubstore: never[];
+	escrowSubstore: EscrowSubstoreEntry[];
+	supportedTokensSubstore: SupportedTokensSubstoreEntry[];
 }
 
 export interface SharingCoefficient {

--- a/test/unit/assets/auth.spec.ts
+++ b/test/unit/assets/auth.spec.ts
@@ -11,7 +11,8 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { addAuthModuleEntry, getAuthModuleEntry } from '../../../src/assets/auth';
+import { getLisk32AddressFromAddress } from '@liskhq/lisk-cryptography';
+import { getAuthModuleEntry, getAuthModuleEntryBuffer } from '../../../src/assets/auth';
 import { MODULE_NAME_AUTH } from '../../../src/constants';
 import {
 	Account,
@@ -84,8 +85,8 @@ describe('Build assets/auth', () => {
 		];
 	});
 
-	it('should get auth store entry', async () => {
-		const response: AuthStoreEntryBuffer = await getAuthModuleEntry(accounts[0]);
+	it('should get auth module substore entries Buffer', async () => {
+		const response: AuthStoreEntryBuffer = await getAuthModuleEntryBuffer(accounts[0]);
 
 		expect(Object.getOwnPropertyNames(response)).toEqual(['storeKey', 'storeValue']);
 		expect(response.storeKey).toBeInstanceOf(Buffer);
@@ -97,9 +98,18 @@ describe('Build assets/auth', () => {
 		]);
 	});
 
-	it('should get auth accounts', async () => {
-		const authStoreEntryBuffer: AuthStoreEntryBuffer = await getAuthModuleEntry(accounts[0]);
-		const response: GenesisAssetEntry = await addAuthModuleEntry([authStoreEntryBuffer]);
+	it('should get auth module substore entries', async () => {
+		const authStoreEntries: AuthStoreEntryBuffer = await getAuthModuleEntryBuffer(accounts[0]);
+
+		const response: GenesisAssetEntry = await getAuthModuleEntry(
+			[authStoreEntries]
+				.sort((a, b) => a.storeKey.compare(b.storeKey))
+				.map(entry => ({
+					...entry,
+					storeKey: getLisk32AddressFromAddress(entry.storeKey),
+				})),
+		);
+
 		const authDataSubstore = (response.data.authDataSubstore as unknown) as AuthStoreEntry[];
 
 		expect(response.module).toEqual(MODULE_NAME_AUTH);

--- a/test/unit/assets/auth.spec.ts
+++ b/test/unit/assets/auth.spec.ts
@@ -12,10 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { addAuthModuleEntry } from '../../../src/assets/auth';
-import { MODULE_NAME_AUTH } from '../../../src/constants';
-import { Account, AuthAccountEntry, AuthStoreEntry, GenesisAssetEntry } from '../../../src/types';
+import { Account, AuthStoreEntryBuffer } from '../../../src/types';
 import { createFakeDefaultAccount } from '../utils/account';
-import { ADDRESS_LISK32 } from '../utils/regex';
 
 describe('Build assets/auth', () => {
 	let accounts: Account[];
@@ -79,20 +77,15 @@ describe('Build assets/auth', () => {
 	});
 
 	it('should get auth accounts', async () => {
-		const response: GenesisAssetEntry = await addAuthModuleEntry(accounts);
-		const authDataSubstore = (response.data.authDataSubstore as unknown) as AuthStoreEntry[];
+		const response: AuthStoreEntryBuffer = await addAuthModuleEntry(accounts[0]);
 
-		expect(response.module).toEqual(MODULE_NAME_AUTH);
-		expect(authDataSubstore).toHaveLength(2);
-		expect(Object.getOwnPropertyNames(authDataSubstore[0])).toEqual(['storeKey', 'storeValue']);
-		authDataSubstore.forEach((asset: { storeKey: string; storeValue: AuthAccountEntry }) => {
-			expect(asset.storeKey).toEqual(expect.stringMatching(ADDRESS_LISK32));
-			expect(Object.getOwnPropertyNames(asset.storeValue)).toEqual([
-				'numberOfSignatures',
-				'mandatoryKeys',
-				'optionalKeys',
-				'nonce',
-			]);
-		});
+		expect(Object.getOwnPropertyNames(response)).toEqual(['storeKey', 'storeValue']);
+		expect(response.storeKey).toBeInstanceOf(Buffer);
+		expect(Object.getOwnPropertyNames(response.storeValue)).toEqual([
+			'numberOfSignatures',
+			'mandatoryKeys',
+			'optionalKeys',
+			'nonce',
+		]);
 	});
 });

--- a/test/unit/assets/interoperability.spec.ts
+++ b/test/unit/assets/interoperability.spec.ts
@@ -11,13 +11,13 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { addInteropModuleEntry } from '../../../src/assets/interoperability';
+import { getInteropModuleEntry } from '../../../src/assets/interoperability';
 import { CHAIN_NAME_MAINCHAIN, MODULE_NAME_INTEROPERABILITY } from '../../../src/constants';
 import { GenesisAssetEntry } from '../../../src/types';
 
 describe('Build assets/interoperability', () => {
 	it('should create interoperability module asset', async () => {
-		const response: GenesisAssetEntry = await addInteropModuleEntry();
+		const response: GenesisAssetEntry = await getInteropModuleEntry();
 		expect(response.module).toEqual(MODULE_NAME_INTEROPERABILITY);
 		expect(Object.getOwnPropertyNames(response.data)).toEqual([
 			'ownChainName',

--- a/test/unit/assets/legacy.spec.ts
+++ b/test/unit/assets/legacy.spec.ts
@@ -14,7 +14,7 @@
 import { hash, getKeys, getFirstEightBytesReversed } from '@liskhq/lisk-cryptography';
 import { codec } from '@liskhq/lisk-codec';
 
-import { addLegacyModuleEntry } from '../../../src/assets/legacy';
+import { getLegacyModuleEntry } from '../../../src/assets/legacy';
 import { MODULE_NAME_LEGACY } from '../../../src/constants';
 import { unregisteredAddressesSchema } from '../../../src/schemas';
 import { UnregisteredAccount, LegacyStoreData, LegacyStoreEntry } from '../../../src/types';
@@ -46,7 +46,7 @@ describe('Build assets/legacy', () => {
 		},
 	};
 
-	describe('addLegacyModuleEntry', () => {
+	describe('getLegacyModuleEntry', () => {
 		beforeAll(async () => {
 			for (const account of Object.values(testAccounts)) {
 				unregisteredAddresses = [];
@@ -62,7 +62,7 @@ describe('Build assets/legacy', () => {
 		});
 
 		it('should get legacy accounts', async () => {
-			const response = await addLegacyModuleEntry(encodedUnregisteredAddresses, undefined);
+			const response = await getLegacyModuleEntry(encodedUnregisteredAddresses, undefined);
 			const data = (response.data as unknown) as LegacyStoreData;
 
 			// Assert

--- a/test/unit/assets/legacy.spec.ts
+++ b/test/unit/assets/legacy.spec.ts
@@ -62,7 +62,7 @@ describe('Build assets/legacy', () => {
 		});
 
 		it('should get legacy accounts', async () => {
-			const response = await addLegacyModuleEntry(encodedUnregisteredAddresses);
+			const response = await addLegacyModuleEntry(encodedUnregisteredAddresses, undefined);
 			const data = (response.data as unknown) as LegacyStoreData;
 
 			// Assert

--- a/test/unit/assets/pos.spec.ts
+++ b/test/unit/assets/pos.spec.ts
@@ -37,7 +37,7 @@ import {
 	createStakersArrayEntry,
 	getStakes,
 	getValidatorKeys,
-	addPoSModuleEntry,
+	getPoSModuleEntry,
 } from '../../../src/assets/pos';
 
 jest.mock('@liskhq/lisk-db');
@@ -288,7 +288,7 @@ describe('Build assets/pos', () => {
 		const staker = (await createStakersArrayEntry(accounts[1], tokenID)) as StakerBuffer;
 		const genesisDataObj = await createGenesisDataObj(accounts, delegates, snapshotHeight);
 
-		const posModuleAsset = await addPoSModuleEntry(
+		const posModuleAsset = await getPoSModuleEntry(
 			[validator].map(e => ({ ...e, address: getLisk32AddressFromAddress(e.address) })),
 			[staker].map(e => ({ ...e, address: getLisk32AddressFromAddress(e.address) })),
 			genesisDataObj,

--- a/test/unit/assets/token.spec.ts
+++ b/test/unit/assets/token.spec.ts
@@ -24,7 +24,7 @@ import { createFakeDefaultAccount } from '../utils/account';
 import {
 	createUserSubstoreArrayEntry,
 	createLegacyReserveAccount,
-	addTokenModuleEntry,
+	getTokenModuleEntry,
 } from '../../../src/assets/token';
 import { MODULE_NAME_TOKEN } from '../../../src/constants';
 
@@ -165,7 +165,7 @@ describe('Build assets/token', () => {
 			tokenID,
 		)) as UserSubstoreEntryBuffer;
 
-		const response = await addTokenModuleEntry(
+		const response = await getTokenModuleEntry(
 			[userSubstore].map(e => ({
 				...e,
 				address: getLisk32AddressFromAddress(e.address),

--- a/test/unit/createAsset.spec.ts
+++ b/test/unit/createAsset.spec.ts
@@ -119,8 +119,23 @@ describe('Build assets/legacy', () => {
 							isBanned: false,
 							totalVotesReceived: BigInt('0'),
 						},
-						sentVotes: [],
-						unlocking: [],
+						sentVotes: [
+							{
+								delegateAddress: Buffer.from('03f6d90b7dbd0497dc3a52d1c27e23bb8c75897f', 'hex'),
+								amount: BigInt('1000000000000'),
+							},
+							{
+								delegateAddress: Buffer.from('0903f4c5cb599a7928aef27e314e98291d1e3888', 'hex'),
+								amount: BigInt('1000000000000'),
+							},
+						],
+						unlocking: [
+							{
+								delegateAddress: Buffer.from('03f6d90b7dbd0497dc3a52d1c27e23bb8c75897f', 'hex'),
+								amount: BigInt(140000000000),
+								unvoteHeight: 21187466,
+							},
+						],
 					},
 				}),
 				createFakeDefaultAccount({


### PR DESCRIPTION
### What was the problem?

This PR resolves #110 

### How was it solved?

- [x] Iterate over the accounts only once and process the genesisAssets for each module individually
- [x] Iterate over the legacyAccounts only once 
  - [x] Create legacy assets
  - [x] Cache legacy reserve amount
- [x] Ensure that the genesis blocks created before and after the change result in same hash/blockID
- [x] The migration times should've reduced

### How was it tested?
Local 
- [x] testnet
- [x] mainnet

### Additional information
Result of optimisation: 
Testnet:
- before --> 15 mins
- after --> 6 mins


Mainnet:
- before --> 4 hours
- after --> 3 hours