### PR TITLE
Copy DB snapshot to support Lisk Core v4 legacy blocks query

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,5 +88,6 @@ export const DEFAULT_DATA_DIR = 'data';
 export const SNAPSHOT_DIR = `${DEFAULT_DATA_DIR}/backup`;
 export const MIN_SUPPORTED_LISK_CORE_VERSION = '3.1.0';
 export const DEFAULT_LISK_CORE_PATH = '~/.lisk/lisk-core';
+export const LEGACY_DB = 'legacy.db';
 
 export const DEFAULT_VERSION = '0.1.0';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,6 +88,6 @@ export const DEFAULT_DATA_DIR = 'data';
 export const SNAPSHOT_DIR = `${DEFAULT_DATA_DIR}/backup`;
 export const MIN_SUPPORTED_LISK_CORE_VERSION = '3.1.0';
 export const DEFAULT_LISK_CORE_PATH = '~/.lisk/lisk-core';
-export const LEGACY_DB = 'legacy.db';
+export const LEGACY_DB_PATH = `${DEFAULT_DATA_DIR}/legacy.db`;
 
 export const DEFAULT_VERSION = '0.1.0';

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
 	MIN_SUPPORTED_LISK_CORE_VERSION,
 	DEFAULT_LISK_CORE_PATH,
 	SNAPSHOT_TIME_GAP,
+	LEGACY_DB,
 } from './constants';
 import { getAPIClient } from './client';
 import {
@@ -48,7 +49,7 @@ import { createGenesisBlock, writeGenesisBlock } from './utils/genesis_block';
 import { CreateAsset } from './createAsset';
 import { ApplicationConfigV3, NetworkConfigLocal, NodeInfo } from './types';
 import { installLiskCore, startLiskCore } from './utils/node';
-import { resolveAbsolutePath } from './utils/fs';
+import { copyDir, resolveAbsolutePath } from './utils/fs';
 
 let finalConfigCorev4: PartialApplicationConfig;
 class LiskMigrator extends Command {
@@ -260,6 +261,12 @@ class LiskMigrator extends Command {
 						finalConfigCorev4 = configV4;
 					}
 
+					cli.action.start(`Creating legacy.db at ${liskCoreV3Path}/data/${LEGACY_DB}`);
+					const legacyDBPath = `${liskCoreV3Path}/data/${LEGACY_DB}`;
+					await copyDir(snapshotDirPath, legacyDBPath);
+					this.log(`Legacy database has been created at ${liskCoreV3Path}/data/${LEGACY_DB}.`);
+					cli.action.stop();
+
 					// Ask user to manually stop Lisk Core v3 and continue
 					const isLiskCoreV3Stopped = await cli.confirm(`
 					Please stop Lisk Core v3 to continue. Type 'yes' and press Enter when ready. [yes/no]`);
@@ -289,6 +296,8 @@ class LiskMigrator extends Command {
 					/* eslint-disable-next-line @typescript-eslint/restrict-template-expressions */
 					this.error(`Failed to auto-start Lisk Core v4.\nError: ${err}`);
 				}
+			} else {
+				this.log('');
 			}
 		} catch (error) {
 			this.error(error as string);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
 	MIN_SUPPORTED_LISK_CORE_VERSION,
 	DEFAULT_LISK_CORE_PATH,
 	SNAPSHOT_TIME_GAP,
-	LEGACY_DB,
+	LEGACY_DB_PATH,
 } from './constants';
 import { getAPIClient } from './client';
 import {
@@ -261,10 +261,9 @@ class LiskMigrator extends Command {
 						finalConfigCorev4 = configV4;
 					}
 
-					cli.action.start(`Creating legacy.db at ${liskCoreV3Path}/data/${LEGACY_DB}`);
-					const legacyDBPath = `${liskCoreV3Path}/data/${LEGACY_DB}`;
-					await copyDir(snapshotDirPath, legacyDBPath);
-					this.log(`Legacy database has been created at ${liskCoreV3Path}/data/${LEGACY_DB}.`);
+					cli.action.start(`Creating legacy.db at ${LEGACY_DB_PATH}`);
+					await copyDir(snapshotDirPath, LEGACY_DB_PATH);
+					this.log(`Legacy database has been created at ${LEGACY_DB_PATH}`);
 					cli.action.stop();
 
 					// Ask user to manually stop Lisk Core v3 and continue
@@ -297,7 +296,9 @@ class LiskMigrator extends Command {
 					this.error(`Failed to auto-start Lisk Core v4.\nError: ${err}`);
 				}
 			} else {
-				this.log('');
+				this.log(
+					`Please copy ${snapshotDirPath} directory to the Lisk Core V4 data directory in order to access legacy blockchain information`,
+				);
 			}
 		} catch (error) {
 			this.error(error as string);

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -14,6 +14,7 @@
 import { homedir } from 'os';
 import * as tar from 'tar';
 import fs from 'fs';
+import { join } from 'path';
 
 export const extractTarBall = async (
 	srcFilePath: string,
@@ -50,4 +51,19 @@ export const rmdir = async (directoryPath: string, options = {}): Promise<boolea
 export const resolveAbsolutePath = (path: string) => {
 	const homeDirectory = homedir();
 	return homeDirectory ? path.replace(/^~(?=$|\/|\\)/, homeDirectory) : path;
+};
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+export const copyDir = async (src: string, dest: string) => {
+	await fs.promises.mkdir(dest, { recursive: true });
+	const files = await fs.promises.readdir(src, { withFileTypes: true });
+
+	for (const fileInfo of files) {
+		const srcPath = join(src, fileInfo.name);
+		const destPath = join(dest, fileInfo.name);
+
+		fileInfo.isDirectory()
+			? await copyDir(srcPath, destPath)
+			: await fs.promises.copyFile(srcPath, destPath);
+	}
 };

--- a/test/unit/utils/fs.spec.ts
+++ b/test/unit/utils/fs.spec.ts
@@ -15,10 +15,12 @@
 import { homedir } from 'os';
 import { join } from 'path';
 
-import { extractTarBall, exists, rmdir, resolveAbsolutePath } from '../../../src/utils/fs';
+import { extractTarBall, exists, rmdir, resolveAbsolutePath, copyDir } from '../../../src/utils/fs';
 
 const testDir = `${process.cwd()}/test/data`;
 const tarFilePath = `${process.cwd()}/test/unit/fixtures/blockchain.db.tar.gz`;
+
+afterAll(async () => rmdir(testDir, { force: true, recursive: true }));
 
 describe('Test extractTarBall method', () => {
 	it('should extract tar file', async () => {
@@ -69,5 +71,18 @@ describe('Test resolveAbsolutePath method', () => {
 		const path = '/.test/testFolder';
 		const absolutePath = resolveAbsolutePath(path);
 		expect(absolutePath).toBe(path);
+	});
+});
+
+describe('Test copyDir method', () => {
+	it('should copy directory', async () => {
+		const sourcePath = `${process.cwd()}/test/unit/fixtures`;
+		const destinationPath = `${testDir}/fixtures`;
+		await copyDir(sourcePath, destinationPath);
+		expect(await exists(destinationPath)).toBe(true);
+	});
+
+	it('should throw when called with empty string', async () => {
+		await expect(copyDir('', '')).rejects.toThrow();
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #140 

### How was it solved?

- [x] When user enables the auto-start-lisk-core-v4 option, migrator automatically copies (recursive) the backup (Lisk Core v3 snapshot) to ~/.lisk/lisk-core/data/legacy.db
  - [x] User is explicitly informed of the creation of legacy.db
- [x] When auto-start-lisk-core-v4 option is disabled, inform the user to manually copy the ${lisk-core-v3-data-path}/data/backup directory to the Lisk Core v4 data directory, if they continue to need access to the legacy blockchain information
- [ ] Add unit tests

### How was it tested?
Local