### PR TITLE
Export forging status

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -5,6 +5,8 @@ This section explains how to migrate a Lisk Core v3.0.4 (or later) node to Lisk 
 The Lisk Migrator CLI tool will generate a new genesis (snapshot) block for Lisk Core v4.x.
 The new genesis block is created based on a snapshot of the existing blockchain (running on Lisk Core v3.0.4+) at a pre-determined height.
 
+Lisk migrator automatically exports node forging status information to a file named `forgingStatus.json` in the output directory. In case the migrater is unable to save to the disk, forging status information is available in the logs.
+
 <!--
 
 > Note: Please ensure that the file name and the checksum filename are the same, whereby the checksum file has an additional extension (lisk-migrator-v2.0.0.tar.gz, and will have a checksum file by the name of lisk-migrator-v2.0.0.tar.gz.SHA256), and are present in the same directory.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -5,7 +5,7 @@ This section explains how to migrate a Lisk Core v3.0.4 (or later) node to Lisk 
 The Lisk Migrator CLI tool will generate a new genesis (snapshot) block for Lisk Core v4.x.
 The new genesis block is created based on a snapshot of the existing blockchain (running on Lisk Core v3.0.4+) at a pre-determined height.
 
-Lisk migrator automatically exports node forging status information to a file named `forgingStatus.json` in the output directory. In case the migrater is unable to save to the disk, forging status information is available in the logs.
+Lisk Migrator automatically exports the node's Forging Status information to the file named `forgingStatus.json` under the output directory. In case, Lisk Migrator is unable to save to the disk, as a fallback, the Forging Status information is logged to the standard output.
 
 <!--
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,29 +11,9 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { resolve } from 'path';
 import { createIPCClient, APIClient } from '@liskhq/lisk-api-client';
-import { Block } from '@liskhq/lisk-chain';
-import { NEW_BLOCK_EVENT_NAME } from './constants';
-import { write } from './utils/fs';
 
 export const getAPIClient = async (liskCorePath: string): Promise<APIClient> => {
 	const client = await createIPCClient(liskCorePath);
 	return client;
-};
-
-export const subscribeToNewBlockEvent = (
-	client: APIClient,
-	snapshotHeight: number,
-	outputDir: string,
-) => {
-	client.subscribe(NEW_BLOCK_EVENT_NAME, async data => {
-		const { block: encodedBlock } = (data as unknown) as Record<string, string>;
-		const newBlock = client.block.decode(Buffer.from(encodedBlock, 'hex')) as Block;
-		if (newBlock.header.height === snapshotHeight) {
-			const forgingStatus = await client.invoke('app:getForgingStatus');
-			const forgingStatusJsonFilepath = resolve(outputDir, 'forgingStatus.json');
-			await write(forgingStatusJsonFilepath, JSON.stringify(forgingStatus));
-		}
-	});
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,9 +11,29 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+import { resolve } from 'path';
 import { createIPCClient, APIClient } from '@liskhq/lisk-api-client';
+import { Block } from '@liskhq/lisk-chain';
+import { NEW_BLOCK_EVENT_NAME } from './constants';
+import { write } from './utils/fs';
 
 export const getAPIClient = async (liskCorePath: string): Promise<APIClient> => {
 	const client = await createIPCClient(liskCorePath);
 	return client;
+};
+
+export const subscribeToNewBlockEvent = (
+	client: APIClient,
+	snapshotHeight: number,
+	outputDir: string,
+) => {
+	client.subscribe(NEW_BLOCK_EVENT_NAME, async data => {
+		const { block: encodedBlock } = (data as unknown) as Record<string, string>;
+		const newBlock = client.block.decode(Buffer.from(encodedBlock, 'hex')) as Block;
+		if (newBlock.header.height === snapshotHeight) {
+			const forgingStatus = await client.invoke('app:getForgingStatus');
+			const forgingStatusJsonFilepath = resolve(outputDir, 'forgingStatus.json');
+			await write(forgingStatusJsonFilepath, JSON.stringify(forgingStatus));
+		}
+	});
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,4 +90,4 @@ export const DEFAULT_LISK_CORE_PATH = '~/.lisk/lisk-core';
 export const LEGACY_DB_PATH = `${DEFAULT_LISK_CORE_PATH}/${DEFAULT_DATA_DIR}/legacy.db`;
 
 export const DEFAULT_VERSION = '0.1.0';
-export const NEW_BLOCK_EVENT_NAME = 'app:block:new';
+export const EVENT_NEW_BLOCK = 'app:block:new';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,3 +90,4 @@ export const DEFAULT_LISK_CORE_PATH = '~/.lisk/lisk-core';
 export const LEGACY_DB_PATH = `${DEFAULT_LISK_CORE_PATH}/${DEFAULT_DATA_DIR}/legacy.db`;
 
 export const DEFAULT_VERSION = '0.1.0';
+export const NEW_BLOCK_EVENT_NAME = 'app:block:new';

--- a/src/events.ts
+++ b/src/events.ts
@@ -12,12 +12,15 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { resolve } from 'path';
+import { Command } from '@oclif/command';
+
 import { APIClient } from '@liskhq/lisk-api-client';
 import { Block } from '@liskhq/lisk-chain';
 import { EVENT_NEW_BLOCK } from './constants';
 import { write } from './utils/fs';
 
 export const captureForgingStatusAtSnapshotHeight = (
+	_this: Command,
 	client: APIClient,
 	snapshotHeight: number,
 	outputDir: string,
@@ -28,7 +31,18 @@ export const captureForgingStatusAtSnapshotHeight = (
 		if (newBlock.header.height === snapshotHeight) {
 			const forgingStatus = await client.invoke('app:getForgingStatus');
 			const forgingStatusJsonFilepath = resolve(outputDir, 'forgingStatus.json');
-			await write(forgingStatusJsonFilepath, JSON.stringify(forgingStatus));
+			try {
+				await write(forgingStatusJsonFilepath, JSON.stringify(forgingStatus, null, 2));
+				_this.log(`Finished exporting forging status to ${forgingStatusJsonFilepath}.`);
+			} catch (error) {
+				_this.log(
+					`Unable to write to disk, please find forging status below: \n${JSON.stringify(
+						forgingStatus,
+						null,
+						2,
+					)}`,
+				);
+			}
 		}
 	});
 };

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { resolve } from 'path';
+import { APIClient } from '@liskhq/lisk-api-client';
+import { Block } from '@liskhq/lisk-chain';
+import { EVENT_NEW_BLOCK } from './constants';
+import { write } from './utils/fs';
+
+export const captureForgingStatusAtSnapshotHeight = (
+	client: APIClient,
+	snapshotHeight: number,
+	outputDir: string,
+) => {
+	client.subscribe(EVENT_NEW_BLOCK, async data => {
+		const { block: encodedBlock } = (data as unknown) as Record<string, string>;
+		const newBlock = client.block.decode(Buffer.from(encodedBlock, 'hex')) as Block;
+		if (newBlock.header.height !== snapshotHeight) {
+			const forgingStatus = await client.invoke('app:getForgingStatus');
+			const forgingStatusJsonFilepath = resolve(outputDir, 'forgingStatus.json');
+			await write(forgingStatusJsonFilepath, JSON.stringify(forgingStatus));
+		}
+	});
+};

--- a/src/events.ts
+++ b/src/events.ts
@@ -36,7 +36,7 @@ export const captureForgingStatusAtSnapshotHeight = (
 				_this.log(`Finished exporting forging status to ${forgingStatusJsonFilepath}.`);
 			} catch (error) {
 				_this.log(
-					`Unable to write to disk, please find forging status below: \n${JSON.stringify(
+					`Unable to save the node Forging Status information to the disk, please find it below instead:\n${JSON.stringify(
 						forgingStatus,
 						null,
 						2,

--- a/src/events.ts
+++ b/src/events.ts
@@ -25,7 +25,7 @@ export const captureForgingStatusAtSnapshotHeight = (
 	client.subscribe(EVENT_NEW_BLOCK, async data => {
 		const { block: encodedBlock } = (data as unknown) as Record<string, string>;
 		const newBlock = client.block.decode(Buffer.from(encodedBlock, 'hex')) as Block;
-		if (newBlock.header.height !== snapshotHeight) {
+		if (newBlock.header.height === snapshotHeight) {
 			const forgingStatus = await client.invoke('app:getForgingStatus');
 			const forgingStatusJsonFilepath = resolve(outputDir, 'forgingStatus.json');
 			await write(forgingStatusJsonFilepath, JSON.stringify(forgingStatus));

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import {
 	SNAPSHOT_TIME_GAP,
 	LEGACY_DB_PATH,
 } from './constants';
-import { getAPIClient } from './client';
+import { getAPIClient, subscribeToNewBlockEvent } from './client';
 import {
 	getConfig,
 	migrateUserConfig,
@@ -139,6 +139,8 @@ class LiskMigrator extends Command {
 
 			const networkConstant = NETWORK_CONSTANT[networkIdentifier] as NetworkConfigLocal;
 			const outputDir = `${outputPath}/${networkIdentifier}`;
+
+			subscribeToNewBlockEvent(client, snapshotHeight, outputDir);
 
 			if (autoStartLiskCoreV4) {
 				if (!networkConstant) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import {
 	SNAPSHOT_TIME_GAP,
 	LEGACY_DB_PATH,
 } from './constants';
-import { getAPIClient, subscribeToNewBlockEvent } from './client';
+import { getAPIClient } from './client';
 import {
 	getConfig,
 	migrateUserConfig,
@@ -45,6 +45,7 @@ import {
 	setTokenIDLskByNetID,
 	setPrevSnapshotBlockHeightByNetID,
 } from './utils/chain';
+import { captureForgingStatusAtSnapshotHeight } from './events';
 import { createGenesisBlock, writeGenesisAssets } from './utils/genesis_block';
 import { CreateAsset } from './createAsset';
 import { ApplicationConfigV3, NetworkConfigLocal, NodeInfo } from './types';
@@ -140,7 +141,7 @@ class LiskMigrator extends Command {
 			const networkConstant = NETWORK_CONSTANT[networkIdentifier] as NetworkConfigLocal;
 			const outputDir = `${outputPath}/${networkIdentifier}`;
 
-			subscribeToNewBlockEvent(client, snapshotHeight, outputDir);
+			captureForgingStatusAtSnapshotHeight(client, snapshotHeight, outputDir);
 
 			if (autoStartLiskCoreV4) {
 				if (!networkConstant) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ class LiskMigrator extends Command {
 			const networkConstant = NETWORK_CONSTANT[networkIdentifier] as NetworkConfigLocal;
 			const outputDir = `${outputPath}/${networkIdentifier}`;
 
-			captureForgingStatusAtSnapshotHeight(client, snapshotHeight, outputDir);
+			captureForgingStatusAtSnapshotHeight(this, client, snapshotHeight, outputDir);
 
 			if (autoStartLiskCoreV4) {
 				if (!networkConstant) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ class LiskMigrator extends Command {
 				label: 'Waiting for snapshot height to be finalized',
 				liskCoreV3DataPath,
 				height: snapshotHeight,
-				delay: nodeInfo.genesisConfig.blockTime * 1000,
+				delay: 500,
 				isFinal: true,
 			});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ class LiskMigrator extends Command {
 				label: 'Waiting for snapshot height to be finalized',
 				liskCoreV3DataPath,
 				height: snapshotHeight,
-				delay: 500,
+				delay: nodeInfo.genesisConfig.blockTime * 1000,
 				isFinal: true,
 			});
 

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -67,3 +67,13 @@ export const copyDir = async (src: string, dest: string) => {
 			: await fs.promises.copyFile(srcPath, destPath);
 	}
 };
+
+export const write = async (filePath: string, content: string): Promise<boolean | Error> =>
+	new Promise((resolve, reject) => {
+		fs.writeFile(filePath, content, err => {
+			if (err) {
+				return reject(err);
+			}
+			return resolve(true);
+		});
+	});

--- a/test/unit/utils/fs.spec.ts
+++ b/test/unit/utils/fs.spec.ts
@@ -15,7 +15,15 @@
 import { homedir } from 'os';
 import { join } from 'path';
 
-import { extractTarBall, exists, rmdir, resolveAbsolutePath, copyDir } from '../../../src/utils/fs';
+import {
+	extractTarBall,
+	exists,
+	rmdir,
+	resolveAbsolutePath,
+	copyDir,
+	write,
+} from '../../../src/utils/fs';
+import { configV3 } from '../fixtures/config';
 
 const testDir = `${process.cwd()}/test/data`;
 const tarFilePath = `${process.cwd()}/test/unit/fixtures/blockchain.db.tar.gz`;
@@ -84,5 +92,20 @@ describe('Test copyDir method', () => {
 
 	it('should throw when called with empty string', async () => {
 		await expect(copyDir('', '')).rejects.toThrow();
+	});
+});
+
+describe('Test write method', () => {
+	it('should write to file when write() method is called', async () => {
+		const filePath = `${testDir}/config.json`;
+		expect(await exists(filePath)).toBe(false);
+
+		await write(filePath, JSON.stringify(configV3));
+
+		expect(await exists(filePath)).toBe(true);
+	});
+
+	it('should throw when called with empty string', async () => {
+		await expect(write('', '')).rejects.toThrow();
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #156 

### How was it solved?

- [x] When the chain height reaches the specified snapshot-height, the forging status is snapshotted (via app:getForgingStatus action invocation against Lisk Core v3)
- [x] The output is saved to the disk under the path: `${outputDir}/forgingStatus.json`
- [x] Add tests

### How was it tested?
Local against testnet