### PR TITLE
Lisk Migrator crashes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,15 @@
  */
 import { createIPCClient, APIClient } from '@liskhq/lisk-api-client';
 
+const clientCache: Record<string, APIClient> = {};
+
 export const getAPIClient = async (liskCorePath: string): Promise<APIClient> => {
-	const client = await createIPCClient(liskCorePath);
-	return client;
+	let _client = clientCache[liskCorePath];
+
+	if (!_client) {
+		_client = await createIPCClient(liskCorePath);
+		clientCache[liskCorePath] = _client;
+	}
+
+	return _client;
 };


### PR DESCRIPTION
### What was the problem?

This PR resolves #155 

### How was it solved?

- [x] Cache and reuse the API client

### How was it tested?

- Run the migrator against testnet with a snapshot height (used: `20449414`) that is far in the future and let it run for over 12hrs and observe the logs/server stats
