### PR TITLE
Fix minimumCertifyHeight in default testnet config

### DIFF
--- a/config/testnet/config.json
+++ b/config/testnet/config.json
@@ -17,7 +17,7 @@
 		"blockTime": 10,
 		"chainID": "01000000",
 		"maxTransactionsSize": 15360,
-		"minimumCertifyHeight": 26689155
+		"minimumCertifyHeight": 20520176
 	},
 	"network": {
 		"version": "4.0",


### PR DESCRIPTION
### What was the problem?

This PR resolves #176 

### How was it solved?

- [x] Updated `minimumCertifyHeight` in default testnet config

### How was it tested?

Locally
