### PR TITLE
Migrator crashes if unexpected directories exist under config directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,8 +174,8 @@ class LiskMigrator extends Command {
 
 			// User specified custom config file
 			const configV3: ApplicationConfigV3 = customConfigPath
-				? await getConfig(liskCoreV3DataPath, customConfigPath)
-				: await getConfig(liskCoreV3DataPath);
+				? await getConfig(this, liskCoreV3DataPath, networkIdentifier, customConfigPath)
+				: await getConfig(this, liskCoreV3DataPath, networkIdentifier);
 
 			await setTokenIDLskByNetID(networkIdentifier);
 			await setPrevSnapshotBlockHeightByNetID(networkIdentifier);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -94,26 +94,26 @@ export const migrateUserConfig = async (
 	cli.action.start('Starting migration of custom config properties.');
 
 	// Assign default version if not available
-	if (!configV4.system.version) {
+	if (!configV4?.system?.version) {
 		cli.action.start(`Setting config property 'system.version' to: ${DEFAULT_VERSION}.`);
 		configV4.system.version = DEFAULT_VERSION;
 		cli.action.stop();
 	}
 
-	if (configV3.rootPath) {
+	if (configV3?.rootPath) {
 		cli.action.start(`Setting config property 'system.dataPath' to: ${configV3.rootPath}.`);
 		configV4.system.dataPath = configV3.rootPath;
 		cli.action.stop();
 	}
 
-	if (configV3.logger) {
+	if (configV3?.logger) {
 		const logLevel = getLogLevel(configV3.logger);
 		cli.action.start(`Setting config property 'system.logLevel' to: ${logLevel}.`);
 		configV4.system.logLevel = logLevel;
 		cli.action.stop();
 	}
 
-	if (configV3.transactionPool) {
+	if (configV3?.transactionPool) {
 		if (configV3.transactionPool.maxTransactions) {
 			cli.action.start(
 				`Setting config property 'transactionPool.maxTransactions' to: ${configV3.transactionPool.maxTransactions}.`,
@@ -123,7 +123,7 @@ export const migrateUserConfig = async (
 			cli.action.stop();
 		}
 
-		if (configV3.transactionPool.maxTransactionsPerAccount) {
+		if (configV3?.transactionPool?.maxTransactionsPerAccount) {
 			cli.action.start(
 				`Setting config property 'transactionPool.maxTransactionsPerAccount' to: ${configV3.transactionPool.maxTransactionsPerAccount}.`,
 			);
@@ -132,7 +132,7 @@ export const migrateUserConfig = async (
 			cli.action.stop();
 		}
 
-		if (configV3.transactionPool.transactionExpiryTime) {
+		if (configV3?.transactionPool?.transactionExpiryTime) {
 			cli.action.start(
 				`Setting config property 'transactionPool.transactionExpiryTime' to: ${configV3.transactionPool.transactionExpiryTime}.`,
 			);
@@ -141,7 +141,7 @@ export const migrateUserConfig = async (
 			cli.action.stop();
 		}
 
-		if (configV3.transactionPool.minEntranceFeePriority) {
+		if (configV3?.transactionPool?.minEntranceFeePriority) {
 			cli.action.start(
 				`Setting config property 'transactionPool.minEntranceFeePriority' to: ${configV3.transactionPool.minEntranceFeePriority}.`,
 			);
@@ -150,7 +150,7 @@ export const migrateUserConfig = async (
 			cli.action.stop();
 		}
 
-		if (configV3.transactionPool.minReplacementFeeDifference) {
+		if (configV3?.transactionPool?.minReplacementFeeDifference) {
 			cli.action.start(
 				`Setting config property 'transactionPool.minReplacementFeeDifference' to: ${configV3.transactionPool.minReplacementFeeDifference}.`,
 			);
@@ -160,26 +160,26 @@ export const migrateUserConfig = async (
 		}
 	}
 
-	if (configV3.rpc?.mode) {
+	if (configV3?.rpc?.mode) {
 		cli.action.start(`Setting config property 'rpc.modes' to: ${configV3.rpc.mode}.`);
 		configV4.rpc.modes = [configV3.rpc.mode];
 		cli.action.stop();
 	}
 
-	if (configV3.network) {
-		if (configV3.network.port) {
+	if (configV3?.network) {
+		if (configV3?.network?.port) {
 			cli.action.start(`Setting config property 'network.port' to: ${configV3.network.port}.`);
 			configV4.network.port = configV3.network.port;
 			cli.action.stop();
 		}
 
-		if (configV3.network.hostIp) {
+		if (configV3?.network?.hostIp) {
 			cli.action.start(`Setting config property 'network.host' to: ${configV3.network.hostIp}.`);
 			configV4.network.host = configV3.network.hostIp;
 			cli.action.stop();
 		}
 
-		if (configV3.network.maxOutboundConnections) {
+		if (configV3?.network?.maxOutboundConnections) {
 			cli.action.start(
 				`Setting config property 'network.maxOutboundConnections' to: ${configV3.network.maxOutboundConnections}.`,
 			);
@@ -187,7 +187,7 @@ export const migrateUserConfig = async (
 			cli.action.stop();
 		}
 
-		if (configV3.network.maxInboundConnections) {
+		if (configV3?.network?.maxInboundConnections) {
 			cli.action.start(
 				`Setting config property 'network.maxInboundConnections' to: ${configV3.network.maxInboundConnections}.`,
 			);
@@ -195,7 +195,7 @@ export const migrateUserConfig = async (
 			cli.action.stop();
 		}
 
-		if (configV3.network.wsMaxPayload) {
+		if (configV3?.network?.wsMaxPayload) {
 			cli.action.start(
 				`Setting config property 'network.wsMaxPayload' to: ${configV3.network.wsMaxPayload}.`,
 			);
@@ -203,7 +203,7 @@ export const migrateUserConfig = async (
 			cli.action.stop();
 		}
 
-		if (configV3.network.advertiseAddress) {
+		if (configV3?.network?.advertiseAddress) {
 			cli.action.start(
 				`Setting config property 'network.advertiseAddress' to: ${configV3.network.advertiseAddress}.`,
 			);
@@ -220,7 +220,7 @@ export const migrateUserConfig = async (
 			(NUMBER_ACTIVE_VALIDATORS + NUMBER_STANDBY_VALIDATORS);
 	cli.action.stop();
 
-	if (configV4.modules.pos && !configV4.modules.pos.maxBFTWeightCap) {
+	if (configV4?.modules?.pos && !configV4?.modules?.pos?.maxBFTWeightCap) {
 		cli.action.start(
 			`Setting config property 'modules.pos.maxBFTWeightCap' to: ${MAX_BFT_WEIGHT_CAP}.`,
 		);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -121,7 +121,7 @@ export const migrateUserConfig = async (
 	cli.action.start('Starting migration of custom config properties.');
 
 	// Assign default version if not available
-	if (!configV4?.system?.version) {
+	if (!configV4.system?.version) {
 		cli.action.start(`Setting config property 'system.version' to: ${DEFAULT_VERSION}.`);
 		configV4.system.version = DEFAULT_VERSION;
 		cli.action.stop();
@@ -247,7 +247,7 @@ export const migrateUserConfig = async (
 			(NUMBER_ACTIVE_VALIDATORS + NUMBER_STANDBY_VALIDATORS);
 	cli.action.stop();
 
-	if (configV4?.modules?.pos && !configV4?.modules?.pos?.maxBFTWeightCap) {
+	if (configV4.modules?.pos && !configV4.modules?.pos?.maxBFTWeightCap) {
 		cli.action.start(
 			`Setting config property 'modules.pos.maxBFTWeightCap' to: ${MAX_BFT_WEIGHT_CAP}.`,
 		);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -31,17 +31,6 @@ import {
 } from '../constants';
 import { resolveAbsolutePath } from './fs';
 
-export const NETWORKS = Object.freeze([
-	{
-		name: 'mainnet',
-		networkID: '4c09e6a781fc4c7bdb936ee815de8f94190f8a7519becd9de2081832be309a99',
-	},
-	{
-		name: 'testnet',
-		networkID: '15f0dacc1060e91818224a94286b13aa04279c640bd5d6f193182031d133df7c',
-	},
-]);
-
 const LOG_LEVEL_PRIORITY = Object.freeze({
 	FATAL: 0,
 	ERROR: 1,
@@ -52,8 +41,10 @@ const LOG_LEVEL_PRIORITY = Object.freeze({
 }) as Record<string, number>;
 
 export const getNetworkByNetworkID = (_networkID: string): string | Error => {
-	const networkInfo = NETWORKS.find(info => info.networkID === _networkID);
-	if (!networkInfo) throw new Error('Migrator running against unsupported network.');
+	const networkInfo = NETWORK_CONSTANT[_networkID];
+	if (!networkInfo) {
+		throw new Error('Migrator running against unidentified network. Cannot proceed.');
+	}
 	return networkInfo.name;
 };
 
@@ -80,7 +71,7 @@ export const getConfig = async (
 	_networkID: string,
 	customConfigPath?: string,
 ): Promise<ApplicationConfigV3> => {
-	let network: String | Error = 'mainnet';
+	let network: string | Error = 'mainnet';
 	try {
 		network = getNetworkByNetworkID(_networkID);
 	} catch (err) {

--- a/src/utils/genesis_block.ts
+++ b/src/utils/genesis_block.ts
@@ -20,12 +20,14 @@ import { GenesisAssetEntry } from '../types';
 import { execAsync } from './process';
 import { copyFile } from './fs';
 
+/* eslint-disable func-names, @typescript-eslint/no-explicit-any */
 (BigInt.prototype as any).toJSON = function () {
 	return this.toString();
 };
 (Buffer.prototype as any).toJSON = function () {
 	return this.toString('hex');
 };
+/* eslint-enable func-names, @typescript-eslint/no-explicit-any */
 
 export const createChecksum = async (filePath: string): Promise<string> => {
 	const fileStream = fs.createReadStream(filePath);

--- a/test/unit/utils/config.spec.ts
+++ b/test/unit/utils/config.spec.ts
@@ -16,6 +16,8 @@ import { resolve, join } from 'path';
 import { ApplicationConfig } from 'lisk-framework';
 import { configV3, configV4 } from '../fixtures/config';
 import {
+	NETWORKS,
+	getNetworkByNetworkID,
 	migrateUserConfig,
 	validateConfig,
 	writeConfig,
@@ -55,6 +57,21 @@ describe('Migrate user configuration', () => {
 			invalid: 'invalid',
 		} as unknown) as ApplicationConfig);
 		expect(isValidConfig).toBe(false);
+	});
+});
+
+describe('Test networkIdentifier method', () => {
+	it('should determine network correctly by networkIdentifier', async () => {
+		NETWORKS.forEach(networkInfo => {
+			const network = getNetworkByNetworkID(networkInfo.networkID);
+			expect(network).toBe(networkInfo.name);
+		});
+	});
+
+	it('should throw error with unknown networkIdentifier', async () => {
+		expect(() => getNetworkByNetworkID('unknown network identifier')).toThrowError(
+			'Migrator running against unsupported network.',
+		);
 	});
 });
 

--- a/test/unit/utils/config.spec.ts
+++ b/test/unit/utils/config.spec.ts
@@ -15,8 +15,8 @@ import * as fs from 'fs-extra';
 import { resolve, join } from 'path';
 import { ApplicationConfig } from 'lisk-framework';
 import { configV3, configV4 } from '../fixtures/config';
+import { NETWORK_CONSTANT } from '../../../src/constants';
 import {
-	NETWORKS,
 	getNetworkByNetworkID,
 	migrateUserConfig,
 	validateConfig,
@@ -62,15 +62,15 @@ describe('Migrate user configuration', () => {
 
 describe('Test networkIdentifier method', () => {
 	it('should determine network correctly by networkIdentifier', async () => {
-		NETWORKS.forEach(networkInfo => {
-			const network = getNetworkByNetworkID(networkInfo.networkID);
-			expect(network).toBe(networkInfo.name);
+		Object.keys(NETWORK_CONSTANT).forEach(networkID => {
+			const network = getNetworkByNetworkID(networkID);
+			expect(network).toBe(NETWORK_CONSTANT[networkID].name);
 		});
 	});
 
 	it('should throw error with unknown networkIdentifier', async () => {
-		expect(() => getNetworkByNetworkID('unknown network identifier')).toThrowError(
-			'Migrator running against unsupported network.',
+		expect(() => getNetworkByNetworkID('unknown network identifier')).toThrow(
+			'Migrator running against unidentified network. Cannot proceed.',
 		);
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #175  

### How was it solved?

- [x] Add null checks for conditional checks when migrating user config
- [x] Default log level to `info` when migrating the user config, when `getLogLevel` errors out
- [x] Determine the network based on the v3 networkIdentifier instead of blindly reading the directory name

### How was it tested?

Locally
