### PR TITLE
Export genesis block tar and SHA256 file to the output directory

### DIFF
--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -14,7 +14,7 @@
 import { homedir } from 'os';
 import * as tar from 'tar';
 import fs from 'fs';
-import { join } from 'path';
+import { join, basename } from 'path';
 
 export const extractTarBall = async (
 	srcFilePath: string,
@@ -86,4 +86,12 @@ export const copyFile = async (src: string, dest: string): Promise<boolean | Err
 			}
 			return resolve(true);
 		});
+	});
+
+export const createTarball = async (filePath: string, outputDir: string) =>
+	new Promise((resolve, reject) => {
+		tar
+			.create({ gzip: true, file: `${outputDir}/${basename(filePath)}.tar.gz` }, [filePath])
+			.then(() => resolve(true))
+			.catch(err => reject(err));
 	});

--- a/src/utils/genesis_block.ts
+++ b/src/utils/genesis_block.ts
@@ -18,7 +18,7 @@ import { Block as BlockVersion3 } from '@liskhq/lisk-chain';
 import { SNAPSHOT_TIME_GAP } from '../constants';
 import { GenesisAssetEntry } from '../types';
 import { execAsync } from './process';
-import { copyFile } from './fs';
+import { copyFile, createTarball } from './fs';
 
 (BigInt.prototype as any).toJSON = function () {
 	return this.toString();
@@ -75,3 +75,23 @@ export const copyGenesisBlock = async (
 	currGenesisBlockFilepath: string,
 	liskCoreV4ConfigPath: string,
 ): Promise<boolean | Error> => copyFile(currGenesisBlockFilepath, liskCoreV4ConfigPath);
+
+export const writeGenesisBlock = async (outputDir: string): Promise<void> => {
+	const genesisBlockJsonFilepath = path.resolve(outputDir, 'genesis_block.json');
+	await createTarball(genesisBlockJsonFilepath, outputDir);
+
+	const genesisBlockBlobFilepath = path.resolve(outputDir, 'genesis_block.blob');
+	await createTarball(genesisBlockBlobFilepath, outputDir);
+
+	const genesisBlockJsonHash = await createChecksum(`${genesisBlockJsonFilepath}.tar.gz`);
+	fs.writeFileSync(
+		path.resolve(outputDir, 'genesis_block.json.tar.gz.SHA256'),
+		genesisBlockJsonHash,
+	);
+
+	const genesisBlockBlobHash = await createChecksum(`${genesisBlockBlobFilepath}.tar.gz`);
+	fs.writeFileSync(
+		path.resolve(outputDir, 'genesis_block.blob.tar.gz.SHA256'),
+		genesisBlockBlobHash,
+	);
+};


### PR DESCRIPTION
### What was the problem?

This PR resolves #182 

### How was it solved?

- [ ] Lisk migrator should create following files:
  - [ ] genesis_block.json.tar.gz & genesis_block.json.tar.gz.SHA256
  - [ ] genesis_block.blob.tar.gz & genesis_block.blob.tar.gz.SHA256
- [ ] Export files to the output directory

### How was it tested?
Local